### PR TITLE
Allow string values in mod_status' output.

### DIFF
--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -118,28 +118,45 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 
 	for _, l := range lines {
 		key, v := splitkv(l)
-		if key == "Scoreboard" || key == "" {
-			continue
-		}
-
-		val, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return err
-		}
 
 		switch {
 		case key == "Total Accesses":
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+
 			e.accessesTotal.Set(val)
 			e.accessesTotal.Collect(ch)
 		case key == "Total kBytes":
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+
 			e.kBytesTotal.Set(val)
 			e.kBytesTotal.Collect(ch)
 		case key == "Uptime":
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+
 			e.uptime.Set(val)
 			e.uptime.Collect(ch)
 		case key == "BusyWorkers":
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+
 			e.workers.WithLabelValues("busy").Set(val)
 		case key == "IdleWorkers":
+			val, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+
 			e.workers.WithLabelValues("idle").Set(val)
 		}
 	}

--- a/apache_exporter_test.go
+++ b/apache_exporter_test.go
@@ -9,8 +9,26 @@ import (
 )
 
 const (
-	apache24Status = `Total Accesses: 1
+	apache24Status = `localhost
+ServerVersion: Apache/2.4.16 (Unix)
+ServerMPM: prefork
+Server Built: Jul 22 2015 21:03:09
+CurrentTime: Monday, 16-May-2016 18:37:02 JST
+RestartTime: Monday, 16-May-2016 16:36:41 JST
+ParentServerConfigGeneration: 1
+ParentServerMPMGeneration: 0
+ServerUptimeSeconds: 7220
+ServerUptime: 2 hours 20 seconds
+Load1: 3.23
+Load5: 3.29
+Load15: 2.89
+Total Accesses: 1
 Total kBytes: 2
+CPUUser: 0
+CPUSystem: .03
+CPUChildrenUser: 0
+CPUChildrenSystem: 0
+CPULoad: .000415512
 Uptime: 15664
 ReqPerSec: 6.38407e-5
 BytesPerSec: .130746


### PR DESCRIPTION
mod_status outputs string values. apache_exporter should ignore these values.

ref. https://svn.apache.org/repos/asf/httpd/httpd/trunk/modules/generators/mod_status.c
