### PR TITLE
added support for connection data

### DIFF
--- a/apache_exporter_test.go
+++ b/apache_exporter_test.go
@@ -10,31 +10,35 @@ import (
 
 const (
 	apache24Status = `localhost
-ServerVersion: Apache/2.4.16 (Unix)
-ServerMPM: prefork
-Server Built: Jul 22 2015 21:03:09
-CurrentTime: Monday, 16-May-2016 18:37:02 JST
-RestartTime: Monday, 16-May-2016 16:36:41 JST
+ServerVersion: Apache/2.4.23 (Unix)
+ServerMPM: event
+Server Built: Jul 29 2016 04:26:14
+CurrentTime: Friday, 29-Jul-2016 14:06:15 UTC
+RestartTime: Friday, 29-Jul-2016 13:58:49 UTC
 ParentServerConfigGeneration: 1
 ParentServerMPMGeneration: 0
-ServerUptimeSeconds: 7220
-ServerUptime: 2 hours 20 seconds
-Load1: 3.23
-Load5: 3.29
-Load15: 2.89
-Total Accesses: 1
-Total kBytes: 2
-CPUUser: 0
-CPUSystem: .03
+ServerUptimeSeconds: 445
+ServerUptime: 7 minutes 25 seconds
+Load1: 0.02
+Load5: 0.02
+Load15: 0.00
+Total Accesses: 131
+Total kBytes: 138
+CPUUser: .25
+CPUSystem: .15
 CPUChildrenUser: 0
 CPUChildrenSystem: 0
-CPULoad: .000415512
-Uptime: 15664
-ReqPerSec: 6.38407e-5
-BytesPerSec: .130746
-BytesPerReq: 2048
+CPULoad: .0898876
+Uptime: 445
+ReqPerSec: .294382
+BytesPerSec: 317.555
+BytesPerReq: 1078.72
 BusyWorkers: 1
-IdleWorkers: 4
+IdleWorkers: 74
+ConnsTotal: 0
+ConnsAsyncWriting: 0
+ConnsAsyncKeepAlive: 0
+ConnsAsyncClosing: 0
 Scoreboard: _W___
 `
 
@@ -50,10 +54,12 @@ IdleWorkers: 8
 Scoreboard: _W_______K......................................................................................................................................................................................................................................................
 `
 
-	metricCount = 5
+	metricCountApache22 = 5
+        metricCountApache24 = 9
+
 )
 
-func checkApacheStatus(t *testing.T, status string) {
+func checkApacheStatus(t *testing.T, status string, metricCount int) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(status))
 	})
@@ -81,9 +87,9 @@ func checkApacheStatus(t *testing.T, status string) {
 }
 
 func TestApache22Status(t *testing.T) {
-	checkApacheStatus(t, apache22Status)
+	checkApacheStatus(t, apache22Status, metricCountApache22)
 }
 
 func TestApache24Status(t *testing.T) {
-	checkApacheStatus(t, apache24Status)
+	checkApacheStatus(t, apache24Status, metricCountApache24)
 }


### PR DESCRIPTION
this data from the server-sattus page is exported to prometheus
ConnsTotal: 0
ConnsAsyncWriting: 0
ConnsAsyncKeepAlive: 0
ConnsAsyncClosing: 0

test is now based on apache 2.4.23 status page